### PR TITLE
Prepare for RuntimeException in CastManager constructor.

### DIFF
--- a/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
+++ b/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
@@ -36,18 +36,25 @@ public class CastManager {
 
     CastManager(Context parent) {
         this.parent = parent;
+        CastContext castContext = null;
+        SessionManager sessionManager = null;
+        CastStateListenerImpl castStateListener = null;
         if (GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(parent) == ConnectionResult.SUCCESS) {
-            this.castContext = CastContext.getSharedInstance(parent);
-            this.sessionManager = castContext.getSessionManager();
-            this.castStateListener = new CastStateListenerImpl();
-            castContext.addCastStateListener(this.castStateListener);
-            sessionManager.addSessionManagerListener(new SessionManagerListenerImpl(), CastSession.class);
+            try {
+                castContext = CastContext.getSharedInstance(parent); // possible RuntimeException from this
+                sessionManager = castContext.getSessionManager();
+                castStateListener = new CastStateListenerImpl();
+                castContext.addCastStateListener(castStateListener);
+                sessionManager.addSessionManagerListener(new SessionManagerListenerImpl(), CastSession.class);
+            } catch (RuntimeException re) {
+                Log.w(TAG, "RuntimeException in CastManager.<init>. Cannot cast.", re);
+            }
         } else {
             Log.w(TAG, "Google Play services not installed on device. Cannot cast.");
-            this.castContext = null;
-            this.sessionManager = null;
-            this.castStateListener = null;
         }
+        this.castContext = castContext;
+        this.sessionManager = sessionManager;
+        this.castStateListener = castStateListener;
     }
 
     public static void init(Context ctx) {


### PR DESCRIPTION
This should have been fixed by the 2c8aa7fa0a but we are still getting it. So suggesting here a more definite solution.

```
Caused by java.lang.RuntimeException: com.google.android.gms.dynamite.DynamiteModule$zzc: No acceptable module found. Local version is 0 and remote version is 0.
       at com.google.android.gms.internal.zzayu.zzbx(Unknown Source)
       at com.google.android.gms.internal.zzayu.zza(Unknown Source)
       at com.google.android.gms.cast.framework.CastContext.<init>(Unknown Source)
       at com.google.android.gms.cast.framework.CastContext.getSharedInstance(Unknown Source)
       at com.reactnativegooglecastv3.CastManager.<init>(CastManager.java:40)
       at com.reactnativegooglecastv3.CastManager.init(CastManager.java:54)
```