### PR TITLE
Fix potential memory leaks and crash in "sendMessage"

### DIFF
--- a/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
+++ b/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
@@ -81,7 +81,11 @@ public class CastManager {
     void sendMessage(String namespace, String message) {
         CastSession session = sessionManager.getCurrentCastSession();
         if (session == null) return;
-        session.sendMessage(namespace, message);
+        try {
+            session.sendMessage(namespace, message);
+        } catch (Exception e) {
+            Log.e(TAG, "Could not send a cast message: ", e);
+        }
     }
 
     void setMediaMetadata(String title, String subtitle, String imageUri) {

--- a/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
+++ b/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
@@ -37,16 +37,16 @@ public class CastManager {
     static CastManager instance;
 
     final CastContext castContext;
-    final SessionManager sessionManager;
-    final CastStateListenerImpl castStateListener;
-    final SessionManagerListenerImpl sessionManagerListener;
+    private final SessionManager sessionManager;
+    private final CastStateListenerImpl castStateListener;
+    private final SessionManagerListenerImpl sessionManagerListener;
     ReactContext reactContext;
     CastDevice castDevice;
 
-    RemoteMediaClient mRemoteMediaClient;
-    MediaMetadata mediaMetadata;
+    private RemoteMediaClient mRemoteMediaClient;
+    private MediaMetadata mediaMetadata;
 
-    CastManager(Context parent) {
+    private CastManager(Context parent) {
         if (GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(parent) == ConnectionResult.SUCCESS) {
             this.castContext = CastContext.getSharedInstance(parent);
             this.sessionManager = castContext.getSessionManager();
@@ -78,13 +78,13 @@ public class CastManager {
         sessionManager.removeSessionManagerListener(this.sessionManagerListener, CastSession.class);
     }
 
-    public void sendMessage(String namespace, String message) {
+    void sendMessage(String namespace, String message) {
         CastSession session = sessionManager.getCurrentCastSession();
         if (session == null) return;
         session.sendMessage(namespace, message);
     }
 
-    public void setMediaMetadata(String title, String subtitle, String imageUri) {
+    void setMediaMetadata(String title, String subtitle, String imageUri) {
         mediaMetadata = new MediaMetadata();
 
         mediaMetadata.putString(MediaMetadata.KEY_TITLE, title);
@@ -92,11 +92,11 @@ public class CastManager {
         mediaMetadata.addImage(new WebImage(Uri.parse(imageUri)));
     }
 
-    public void resetMediaMetadata() {
+    void resetMediaMetadata() {
         mediaMetadata = null;
     }
 
-    public void loadVideo(String videoUri) {
+    void loadVideo(String videoUri) {
         CastSession session = sessionManager.getCurrentCastSession();
 
         MediaInfo mediaInfo = new MediaInfo.Builder(videoUri)
@@ -133,7 +133,7 @@ public class CastManager {
         mRemoteMediaClient.load(mediaInfo, true, 0);
     }
 
-    public void loadAudio(String audioUri) {
+    void loadAudio(String audioUri) {
         CastSession session = sessionManager.getCurrentCastSession();
 
         MediaInfo mediaInfo = new MediaInfo.Builder(audioUri)
@@ -169,7 +169,7 @@ public class CastManager {
         mRemoteMediaClient.load(mediaInfo, true, 0);
     }
 
-    public void getMediaState(Callback callback) {
+    void getMediaState(Callback callback) {
         if (mRemoteMediaClient == null) {
             callback.invoke( 0 );
             return;
@@ -178,22 +178,22 @@ public class CastManager {
         callback.invoke( mRemoteMediaClient.getPlayerState() );
     }
 
-    public void togglePlayerState() {
+    void togglePlayerState() {
         if (mRemoteMediaClient.isPlaying())
             mRemoteMediaClient.pause();
         else if (mRemoteMediaClient.isPaused())
             mRemoteMediaClient.play();
     }
 
-    public void seek(int position) {
-        mRemoteMediaClient.seek(position, mRemoteMediaClient.RESUME_STATE_UNCHANGED);
+    void seek(int position) {
+        mRemoteMediaClient.seek(position, RemoteMediaClient.RESUME_STATE_UNCHANGED);
     }
 
-    public void resetCasting() {
+    void resetCasting() {
         mRemoteMediaClient.stop();
     }
 
-    public void disconnect() {
+    void disconnect() {
         try {
             sessionManager.endCurrentSession(true);
         } catch (RuntimeException re) {
@@ -201,7 +201,7 @@ public class CastManager {
         }
     }
 
-    public void triggerStateChange() {
+    void triggerStateChange() {
         this.castStateListener.onCastStateChanged(castContext.getCastState());
     }
 

--- a/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
+++ b/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
@@ -80,7 +80,7 @@ public class CastManager {
 
     void sendMessage(String namespace, String message) {
         CastSession session = sessionManager.getCurrentCastSession();
-        if (session == null) return;
+        if (session == null || !session.isConnected()) return;
         try {
             session.sendMessage(namespace, message);
         } catch (Exception e) {

--- a/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
+++ b/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
@@ -36,7 +36,6 @@ import static com.reactnativegooglecastv3.GoogleCastPackage.metadata;
 public class CastManager {
     static CastManager instance;
 
-    final Context parent;
     final CastContext castContext;
     final SessionManager sessionManager;
     final CastStateListenerImpl castStateListener;
@@ -48,8 +47,6 @@ public class CastManager {
     MediaMetadata mediaMetadata;
 
     CastManager(Context parent) {
-        this.parent = parent;
-
         if (GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(parent) == ConnectionResult.SUCCESS) {
             this.castContext = CastContext.getSharedInstance(parent);
             this.sessionManager = castContext.getSessionManager();

--- a/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
+++ b/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
@@ -1,38 +1,30 @@
 package com.reactnativegooglecastv3;
 
-import java.lang.Math;
-
 import android.content.Context;
+import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
 import android.util.Log;
-import com.facebook.react.bridge.ReactContext;
-import com.google.android.gms.common.ConnectionResult;
 
-import android.content.Context;
-import android.net.Uri;
-import android.util.Log;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactContext;
-
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.android.gms.cast.Cast;
 import com.google.android.gms.cast.CastDevice;
-import com.google.android.gms.cast.MediaMetadata;
 import com.google.android.gms.cast.MediaInfo;
+import com.google.android.gms.cast.MediaMetadata;
 import com.google.android.gms.cast.framework.CastContext;
 import com.google.android.gms.cast.framework.CastSession;
-import com.google.android.gms.cast.framework.CastState;
 import com.google.android.gms.cast.framework.CastStateListener;
 import com.google.android.gms.cast.framework.SessionManager;
 import com.google.android.gms.cast.framework.media.RemoteMediaClient;
 import com.google.android.gms.cast.framework.media.RemoteMediaClient.ProgressListener;
-
+import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.images.WebImage;
 
-import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.bridge.Callback;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 import java.io.IOException;
 
 import static com.google.android.gms.cast.framework.CastState.CONNECTED;

--- a/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
+++ b/android/src/main/java/com/reactnativegooglecastv3/CastManager.java
@@ -209,7 +209,7 @@ public class CastManager {
         @Override
         public void onCastStateChanged(int state) {
             Log.d(TAG, "onCastStateChanged: " + state);
-            if (state == CONNECTING || state == CONNECTED) {
+            if (sessionManager != null && (state == CONNECTING || state == CONNECTED)) {
                 castDevice = sessionManager.getCurrentCastSession().getCastDevice();
             } else {
                 castDevice = null;

--- a/android/src/main/java/com/reactnativegooglecastv3/CastModule.java
+++ b/android/src/main/java/com/reactnativegooglecastv3/CastModule.java
@@ -20,15 +20,17 @@ import java.util.Map;
 import java.lang.Thread;
 
 
+import javax.annotation.Nonnull;
+
 import static com.reactnativegooglecastv3.GoogleCastPackage.APP_ID;
 import static com.reactnativegooglecastv3.GoogleCastPackage.NAMESPACE;
 import static com.reactnativegooglecastv3.GoogleCastPackage.TAG;
 
 public class CastModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
-    final ReactApplicationContext reactContext;
-    final Handler handler;
+    private final ReactApplicationContext reactContext;
+    private final Handler handler;
 
-    public CastModule(ReactApplicationContext reactContext) {
+    CastModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         handler = new Handler(reactContext.getMainLooper());
@@ -169,6 +171,7 @@ public class CastModule extends ReactContextBaseJavaModule implements LifecycleE
         });
     }
 
+    @Nonnull
     @Override
     public String getName() {
         return "GoogleCastV3";

--- a/android/src/main/java/com/reactnativegooglecastv3/CastModule.java
+++ b/android/src/main/java/com/reactnativegooglecastv3/CastModule.java
@@ -1,24 +1,21 @@
 package com.reactnativegooglecastv3;
 
 import android.os.Handler;
-import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactMethod;
+import android.util.Log;
 
-import com.facebook.react.bridge.*;
-import com.google.android.gms.cast.Cast;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.framework.CastState;
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.api.GoogleApiClient;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.util.Log;
-import android.os.Handler;
 import java.util.HashMap;
 import java.util.Map;
-import java.lang.Thread;
-
 
 import javax.annotation.Nonnull;
 
@@ -53,7 +50,7 @@ public class CastModule extends ReactContextBaseJavaModule implements LifecycleE
         });
     }
 
-    @ReactMethod
+    @ReactMethod @SuppressWarnings("unused")
     public void setMediaMetadata(final String title, final String subtitle, final String imageUri) {
         handler.post(new Runnable() {
             @Override
@@ -63,7 +60,7 @@ public class CastModule extends ReactContextBaseJavaModule implements LifecycleE
         });
     }
 
-    @ReactMethod
+    @ReactMethod @SuppressWarnings("unused")
     public void resetMediaMetadata() {
         handler.post(new Runnable() {
             @Override
@@ -73,7 +70,7 @@ public class CastModule extends ReactContextBaseJavaModule implements LifecycleE
         });
     }
 
-    @ReactMethod
+    @ReactMethod @SuppressWarnings("unused")
     public void loadVideo(final String videoUri) {
         handler.post(new Runnable() {
             @Override
@@ -83,7 +80,7 @@ public class CastModule extends ReactContextBaseJavaModule implements LifecycleE
         });
     }
 
-    @ReactMethod
+    @ReactMethod @SuppressWarnings("unused")
     public void loadAudio(final String audioUri) {
         handler.post(new Runnable() {
             @Override
@@ -93,7 +90,7 @@ public class CastModule extends ReactContextBaseJavaModule implements LifecycleE
         });
     }
 
-    @ReactMethod
+    @ReactMethod @SuppressWarnings("unused")
     public void getMediaState(final Callback callback) {
         handler.post(new Runnable() {
             @Override
@@ -103,7 +100,7 @@ public class CastModule extends ReactContextBaseJavaModule implements LifecycleE
         });
     }
 
-    @ReactMethod
+    @ReactMethod @SuppressWarnings("unused")
     public void togglePlayerState() {
         handler.post(new Runnable() {
             @Override
@@ -124,7 +121,7 @@ public class CastModule extends ReactContextBaseJavaModule implements LifecycleE
         });
     }
 
-    @ReactMethod
+    @ReactMethod @SuppressWarnings("unused")
     public void resetCasting() {
         handler.post(new Runnable() {
             @Override

--- a/android/src/main/java/com/reactnativegooglecastv3/CastModule.java
+++ b/android/src/main/java/com/reactnativegooglecastv3/CastModule.java
@@ -5,8 +5,14 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 
 import com.facebook.react.bridge.*;
+import com.google.android.gms.cast.Cast;
 import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.framework.CastState;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.GoogleApiClient;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import android.os.Handler;
 import java.util.HashMap;
@@ -18,7 +24,7 @@ import static com.reactnativegooglecastv3.GoogleCastPackage.APP_ID;
 import static com.reactnativegooglecastv3.GoogleCastPackage.NAMESPACE;
 import static com.reactnativegooglecastv3.GoogleCastPackage.TAG;
 
-public class CastModule extends ReactContextBaseJavaModule {
+public class CastModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
     final ReactApplicationContext reactContext;
     final Handler handler;
 
@@ -26,6 +32,7 @@ public class CastModule extends ReactContextBaseJavaModule {
         super(reactContext);
         this.reactContext = reactContext;
         handler = new Handler(reactContext.getMainLooper());
+        reactContext.addLifecycleEventListener(this);
     }
 
     @Override
@@ -73,7 +80,7 @@ public class CastModule extends ReactContextBaseJavaModule {
             }
         });
     }
-    
+
     @ReactMethod
     public void loadAudio(final String audioUri) {
         handler.post(new Runnable() {
@@ -187,5 +194,36 @@ public class CastModule extends ReactContextBaseJavaModule {
     @Override
     public void onCatalystInstanceDestroy() {
         CastManager.instance.reactContext = null;
+    }
+
+    @Override
+    public void onHostResume() {
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                CastManager.instance.addStateListeners();
+            }
+        });
+
+    }
+
+    @Override
+    public void onHostPause() {
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                CastManager.instance.removeStateListeners();
+            }
+        });
+    }
+
+    @Override
+    public void onHostDestroy() {
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                CastManager.instance.removeStateListeners();
+            }
+        });
     }
 }


### PR DESCRIPTION
Event listeners for CastContext and SessionManager should be cleaned up when activity gets paused or destroyed and added back when activity resumed